### PR TITLE
No need for README.textile to be included

### DIFF
--- a/release/txp-gitdist.sh
+++ b/release/txp-gitdist.sh
@@ -58,6 +58,7 @@ rm textpattern-$VER/textpattern/.gitignore
 rm textpattern-$VER/textpattern/tmp/.gitignore
 rm textpattern-$VER/phpcs.xml
 rm textpattern-$VER/.phpstorm.meta.php
+rm textpattern-$VER/README.textile
 
 tar cvf - -C $DESTDIR textpattern-$VER | gzip -c > textpattern-$VER.tar.gz
 


### PR DESCRIPTION
`README.textile` was created as a GitHub show-and-tell, so is not relevant to distribution. `README.txt` has the salient info.