### PR TITLE
Account for Markdown version of README, introduce MD5 checksumming

### DIFF
--- a/release/txp-gitdist.sh
+++ b/release/txp-gitdist.sh
@@ -58,6 +58,7 @@ rm textpattern-$VER/textpattern/.gitignore
 rm textpattern-$VER/textpattern/tmp/.gitignore
 rm textpattern-$VER/phpcs.xml
 rm textpattern-$VER/.phpstorm.meta.php
+rm textpattern-$VER/README.textile
 rm textpattern-$VER/README.md
 
 tar cvf - -C $DESTDIR textpattern-$VER | gzip -c > textpattern-$VER.tar.gz

--- a/release/txp-gitdist.sh
+++ b/release/txp-gitdist.sh
@@ -61,8 +61,10 @@ rm textpattern-$VER/.phpstorm.meta.php
 rm textpattern-$VER/README.md
 
 tar cvf - -C $DESTDIR textpattern-$VER | gzip -c > textpattern-$VER.tar.gz
+md5 textpattern-$VER.tar.gz > textpattern-$VER.tar.gz.md5
 
 zip -r textpattern-$VER.zip textpattern-$VER --exclude textpattern-$VER/sites/\*
+md5 textpattern-$VER.zip > textpattern-$VER.zip.md5
 
 cd $OLDDIR
 

--- a/release/txp-gitdist.sh
+++ b/release/txp-gitdist.sh
@@ -58,7 +58,7 @@ rm textpattern-$VER/textpattern/.gitignore
 rm textpattern-$VER/textpattern/tmp/.gitignore
 rm textpattern-$VER/phpcs.xml
 rm textpattern-$VER/.phpstorm.meta.php
-rm textpattern-$VER/README.textile
+rm textpattern-$VER/README.md
 
 tar cvf - -C $DESTDIR textpattern-$VER | gzip -c > textpattern-$VER.tar.gz
 


### PR DESCRIPTION
Catch-all for different GitHub-friendly README file(s).

I can improve the MD5 checking (e.g. omit the filename), so consider this a first step.