### PR TITLE
Shave a few bytes off the archive sizes

### DIFF
--- a/release/txp-gitdist.sh
+++ b/release/txp-gitdist.sh
@@ -63,10 +63,10 @@ rm textpattern-$VER/README.md
 rm -rf textpattern-$VER/.github
 
 # Bundle up.
-tar cvf - -C $DESTDIR textpattern-$VER | gzip -c > textpattern-$VER.tar.gz
+tar cvf - -C $DESTDIR textpattern-$VER | gzip -c9 > textpattern-$VER.tar.gz
 shasum -a 256 textpattern-$VER.tar.gz > textpattern-$VER.tar.gz.SHA256SUM
 
-zip --symlinks -r textpattern-$VER.zip textpattern-$VER --exclude textpattern-$VER/sites/\*
+zip --symlinks -r -9 textpattern-$VER.zip textpattern-$VER --exclude textpattern-$VER/sites/\*
 shasum -a 256 textpattern-$VER.zip > textpattern-$VER.zip.SHA256SUM
 
 cd $OLDDIR


### PR DESCRIPTION
Compress more and save a few bytes. Retains compatibility with legacy decompression.

Before:
```
$ ls -l
total 6184
drwxr-xr-x  14 pete  staff      476  1 Sep 10:10 textpattern-4.7.1
-rw-r--r--   1 pete  staff  1456881  1 Sep 10:10 textpattern-4.7.1.tar.gz
-rw-r--r--   1 pete  staff       91  1 Sep 10:10 textpattern-4.7.1.tar.gz.SHA256SUM
-rw-r--r--   1 pete  staff  1699406  1 Sep 10:10 textpattern-4.7.1.zip
-rw-r--r--   1 pete  staff       88  1 Sep 10:10 textpattern-4.7.1.zip.SHA256SUM
```

After:
```
$ ls -l
total 6160
drwxr-xr-x  14 pete  staff      476  1 Sep 10:19 textpattern-4.7.1
-rw-r--r--   1 pete  staff  1448355  1 Sep 10:19 textpattern-4.7.1.tar.gz
-rw-r--r--   1 pete  staff       91  1 Sep 10:19 textpattern-4.7.1.tar.gz.SHA256SUM
-rw-r--r--   1 pete  staff  1693139  1 Sep 10:19 textpattern-4.7.1.zip
-rw-r--r--   1 pete  staff       88  1 Sep 10:19 textpattern-4.7.1.zip.SHA256SUM
```